### PR TITLE
Update dotenv configuration to quiet tips

### DIFF
--- a/server/database/db.js
+++ b/server/database/db.js
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { config } from "dotenv";
-config()
+config({ quiet: true })
 
 const supabase = createClient(process.env.DB_URL_SUPERBASE,process.env.DB_PUBLIC_KEY)
 export default supabase


### PR DESCRIPTION
This pull request makes a minor change to the database configuration by suppressing dotenv's output during initialization.

* Suppressed dotenv output by passing `{ quiet: true }` to the `config` function in `server/database/db.js`.